### PR TITLE
📖 [Docs]: README pages now use the standard module landing-page format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,3 @@ This repository is currently a placeholder. The module source still contains sca
 ## Documentation
 
 When this module is implemented, command details should live in PowerShell help and generated documentation rather than being duplicated in this README.
-
-## Contributing
-
-Issues and pull requests are welcome when implementation work begins.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ GraphQL is intended to be a PowerShell module for simplifying work with GraphQL 
 
 This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported commands or usage examples to document yet.
 
+## Documentation
+
+When this module is implemented, command details should live in PowerShell help and generated documentation rather than being duplicated in this README.
+
 ## Contributing
 
 Issues and pull requests are welcome when implementation work begins.

--- a/README.md
+++ b/README.md
@@ -1,67 +1,11 @@
-# PSModuleTemplate
+# GraphQL
 
-Add a short description about the module and the project.
+GraphQL is intended to be a PowerShell module for simplifying work with GraphQL APIs.
 
-## Prerequisites
+## Status
 
-List any prerequisites needed to use the module, such as PowerShell versions, additional modules, or permissions.
-
-## Installation
-
-Provide step-by-step instructions on how to install the module, including any InstallModule commands or manual installation steps.
-
-```powershell
-Install-Module -Name YourModuleName
-```
-
-## Usage
-
-Here is a list of example that are typical use cases for the module.
-This section should provide a good overview of the module's capabilities.
-
-### Example 1
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Import-Module -Name PSModuleTemplate
-```
-
-### Example 2
-
-Provide examples for typical commands that a user would like to do with the module.
-
-```powershell
-Import-Module -Name PSModuleTemplate
-```
-
-### Find more examples
-
-To find more examples of how to use the module, please refer to the [examples](examples) folder.
-
-Alternatively, you can use the Get-Command -Module 'This module' to find more commands that are available in the module.
-To find examples of each of the commands you can use Get-Help -Examples 'CommandName'.
-
-## Documentation
-
-Link to further documentation if available, or describe where in the repository users can find more detailed documentation about
-the module's functions and features.
+This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported commands or usage examples to document yet.
 
 ## Contributing
 
-Coder or not, you can contribute to the project! We welcome all contributions.
-
-### For Users
-
-If you don't code, you still sit on valuable information that can make this project even better. If you experience that the
-product does unexpected things, throw errors or is missing functionality, you can help by submitting bugs and feature requests.
-Please see the issues tab on this project and submit a new issue that matches your needs.
-
-### For Developers
-
-If you do code, we'd love to have your contributions. Please read the [Contribution guidelines](CONTRIBUTING.md) for more information.
-You can either help by picking up an existing issue or submit a new one if you have an idea for a new feature or improvement.
-
-## Acknowledgements
-
-Here is a list of people and projects that helped this project in some way.
+Issues and pull requests are welcome when implementation work begins.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GraphQL is intended to be a PowerShell module for simplifying work with GraphQL 
 
 ## Status
 
-This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported commands or usage examples to document yet.
+This repository is currently a placeholder. The module source still contains scaffold code, so there are no supported GraphQL-focused commands or usage examples to document yet.
 
 ## Documentation
 


### PR DESCRIPTION
The `GraphQL` README is now a concise placeholder landing page. It clearly states that the module is not yet implemented, so users are not shown scaffold code as if it were working functionality.

## Changed

- Keeps the placeholder shape: overview, `## Status`, and `## Documentation`.
- Removes the `## Contributing` section (community/contribution guidance is handled separately, not in the module landing page).
- No invented commands or usage examples are added, since the module still contains only scaffold code.

## Technical details

- Updates `README.md` only.
- Aligns the placeholder README with the standard module landing-page format introduced in `PSModule/Template-PSModule`.
